### PR TITLE
Update white.list

### DIFF
--- a/pihole/blocklists/data/white.list
+++ b/pihole/blocklists/data/white.list
@@ -530,6 +530,8 @@ syndication.twitter.com
 *.cleverpush.com
 *.crashlytics.com
 cdn.optimizely.com
+j.wfcdn.de
+www.nextplatform.com
 
 # WhatsApp
 *.whatsapp.com


### PR DESCRIPTION
Zwei Domains hinzugefügt.
Winfuture.de funktioniert wieder (j.wfcdn.de) und die andere ist eine Nachrichtenseite.